### PR TITLE
Target .NET 8

### DIFF
--- a/NethermindPruneStarter/NethermindPruneStarter.csproj
+++ b/NethermindPruneStarter/NethermindPruneStarter.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>


### PR DESCRIPTION
I'm not too sure how to actually test this, but I was able to build and run the application:

```sh
root@7e5adde37c5e:/app/NethermindPruneStarter# dotnet build
MSBuild version 17.8.3+195e7f5a3 for .NET
  Determining projects to restore...
  Restored /app/NethermindPruneStarter/NethermindPruneStarter/NethermindPruneStarter.csproj (in 177 ms).
  NethermindPruneStarter -> /app/NethermindPruneStarter/NethermindPruneStarter/bin/Debug/net8.0/NethermindPruneStarter.dll
  The package RocketPool.NethermindPruneStarter.1.0.1 is missing a readme. Go to https://aka.ms/nuget/authoring-best-practices/readme to learn why package readmes are important.
  Successfully created package '/app/NethermindPruneStarter/NethermindPruneStarter/bin/Debug/RocketPool.NethermindPruneStarter.1.0.1.nupkg'.

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:01.82
root@7e5adde37c5e:/app/NethermindPruneStarter# ./NethermindPruneStarter/bin/Debug/net8.0/NethermindPruneStarter http://google.com
Trying again in 3 seconds... (1/100)
Trying again in 3 seconds... (2/100)
```